### PR TITLE
Added url to product on the image in the list

### DIFF
--- a/firesale/views/category.php
+++ b/firesale/views/category.php
@@ -51,7 +51,7 @@
 {{ if image == null }}
             <div class="no_image_180"></div>
 {{ else }}
-            <img src="{{ url:site }}files/thumb/{{ image }}/180/180" alt="{{ title }}" />
+           <a href="/product/{{ slug }}"><img src="{{ url:site }}files/thumb/{{ image }}/180/180" alt="{{ title }}" /></a>
 {{ endif }}
             <section class="price-round medium"><span class="rrp">{{ if rrp > price }}{{ rrp }}{{ endif }}</span><span class="price">{{ settings:currency }}{{ price }}</span></section>
             <header>


### PR DESCRIPTION
Often a user try to access to the product's detail with the click on the image of the product and not on its name.
So, why don't allow them to to that?
