### PR TITLE
Category query problem

### DIFF
--- a/firesale/models/categories_m.php
+++ b/firesale/models/categories_m.php
@@ -136,13 +136,12 @@ class Categories_m extends MY_Model
     {
 
     	// Variables
-		$children = $this->get_children($category);
-    	$query    = $this->db->select('firesale_products.`id`', FALSE)
+	$children = $this->get_children($category);
+    	$query    = $this->db->select('`row_id` AS id', FALSE)
     						 ->from('firesale_products_firesale_categories')
     						 ->join('firesale_products', 'firesale_products.id = firesale_products_firesale_categories.row_id', 'inner')
-    						 ->join('firesale_categories', 'firesale_categories.id = firesale_products_firesale_categories.firesale_categories_id', 'inner')
     						 ->where('firesale_products.status', 1)
-    						 ->group_by('firesale_products.slug');
+    						 ->group_by('firesale_products_firesale_categories.row_id');
 
     	// Has children?
     	if( !empty($children) AND $category != NULL )


### PR DESCRIPTION
I'm trying to understand why its happening and what i'm seeing...  
On the backend my four products all have the correct category in the edit and index screen of products.  But on the front end that category shows only 2 of the products in the category??? all products are Live, as is the category.  

Digging around the select statement ( build_query in categories ) seems to be flawed .. ( maybe im wrong ), there isn't a reason to use a second join to pull the category information when your only retrieving product ids. 
