### PR TITLE
Changes to Default Currency

### DIFF
--- a/firesale/controllers/admin_currency.php
+++ b/firesale/controllers/admin_currency.php
@@ -121,6 +121,9 @@ class Admin_currency extends Admin_Controller
 
             // Run currency update function
             $this->load->library('firesale/exchange');
+            
+            // Update list of currencies in settings
+            $this->currency_m->update_default_currency_options();
 
             // Success, clear cache!
             Events::trigger('clear_cache');
@@ -224,6 +227,9 @@ class Admin_currency extends Admin_Controller
 
             // Delete entry
             $this->streams->entries->delete_entry($id, 'firesale_currency', 'firesale_currency');
+            
+            // Update list of currencies in settings
+            $this->currency_m->update_default_currency_options();
 
             // Success, clear cache!
             Events::trigger('clear_cache');

--- a/firesale/controllers/admin_orders.php
+++ b/firesale/controllers/admin_orders.php
@@ -172,7 +172,7 @@ class Admin_orders extends Admin_Controller
         array_unshift($this->data->fields['bill']['details'], $bill);
 
         // Get currency
-        $this->data->currency = $this->pyrocache->model('currency_m', 'get', array(( $id != NULL && $row->currency != NULL ? $row->currency : 1 ), $this->firesale->cache_time));
+        $this->data->currency = $this->pyrocache->model('currency_m', 'get', array(( $id != NULL && $row->currency != NULL ? $row->currency : NULL ), $this->firesale->cache_time));
 
         // Get products
         if ($id != NULL) {

--- a/firesale/controllers/admin_products.php
+++ b/firesale/controllers/admin_products.php
@@ -71,7 +71,7 @@ class Admin_products extends Admin_Controller
 
         // Build product data
         foreach ($products AS &$product) {
-            $product = $this->pyrocache->model('products_m', 'get_product', array($product['id'], 1), $this->firesale->cache_time);
+            $product = $this->pyrocache->model('products_m', 'get_product', array($product['id']), $this->firesale->cache_time);
         }
 
         // Assign variables

--- a/firesale/details.php
+++ b/firesale/details.php
@@ -850,9 +850,18 @@ class Module_Firesale extends Module
         $return     = TRUE;
         $settings   = array();
         $current    = array();
+        
+        // make list of currencies (if any) for default currency setting
+        $default_currency_options = array();
+        if($currencies = $this->db->get('firesale_currency')->result_array()) {
+            foreach($currencies as $k => $currency) {
+                $default_currency_options[] = $currency['cur_code'].'='.$currency['cur_code'];
+            }
+        }
+        $default_currency_options = implode('|', $default_currency_options);
 
         // Settings
-        $settings[] = array('slug' => 'firesale_currency', 'title' => lang('firesale:settings_currency'), 'description' => lang('firesale:settings_currency_inst'), 'default' => 'GBP', 'value' => 'GBP', 'type' => 'text', 'options' => '', 'is_required' => 1, 'is_gui' => 1, 'module' => 'firesale');
+        $settings[] = array('slug' => 'firesale_currency', 'title' => lang('firesale:settings_currency'), 'description' => lang('firesale:settings_currency_inst'), 'default' => 'GBP', 'value' => 'GBP', 'type' => 'select', 'options' => $default_currency_options, 'is_required' => 1, 'is_gui' => 1, 'module' => 'firesale');
         $settings[] = array('slug' => 'firesale_currency_key', 'title' => lang('firesale:settings_currency_key'), 'description' => lang('firesale:settings_currency_key_inst'), 'default' => '', 'value' => '', 'type' => 'text', 'options' => '', 'is_required' => 0, 'is_gui' => 1, 'module' => 'firesale' );
         $settings[] = array('slug' => 'firesale_current_currency', 'title' => lang('firesale:settings_current_currency'), 'description' => lang('firesale:settings_current_currency_inst'), 'default' => 'GBP', 'value' => 'GBP', 'type' => 'text', 'options' => '', 'is_required' => 0, 'is_gui' => 0, 'module' => 'firesale' );
         $settings[] = array('slug' => 'firesale_currency_updated', 'title' => lang('firesale:settings_currency_updated'), 'description' => lang('firesale:settings_currency_updated_inst'), 'default' => '', 'value' => '', 'type' => 'text', 'options' => '', 'is_required' => 0, 'is_gui' => 0, 'module' => 'firesale');

--- a/firesale/libraries/fs_cart.php
+++ b/firesale/libraries/fs_cart.php
@@ -43,7 +43,7 @@ class Fs_cart extends CI_Cart
     {
         if ( ! isset($this->currency)) {
             $currency = $this->ci->session->userdata('currency');
-            $this->currency = $this->ci->currency_m->get($currency ? $currency : 1);
+            $this->currency = $this->ci->currency_m->get($currency ? $currency : NULL);
         }
 
         return $this->currency;

--- a/firesale/models/currency_m.php
+++ b/firesale/models/currency_m.php
@@ -189,5 +189,44 @@ class Currency_m extends MY_Model
         // Return
         return $formatted;
     }
+    
+    
+    /**
+     * Updates the options for the select/dropdown "Default Currency Code" in settings
+     */
+    public function update_default_currency_options() {
+        // get current setting
+        $setting = $this->db->get_where('settings', array('slug' => 'firesale_currency'))->row_array();
+/*         var_dump($setting); */
+        
+        $options = array();
+        $codes = array();
+        if($currencies = $this->db->get('firesale_currency')->result_array()) {
+            foreach($currencies as $k => $currency) {
+                $codes[$currency['cur_code']] = $currency['cur_code'];
+                $options[] = $currency['cur_code'].'='.$currency['cur_code'];
+            }
+        }
+        $setting['options'] = implode('|', $options);
+        
+        // make sure saved currency is still in the list (it might have been deleted)
+        if(!isset($codes[$setting['value']])) {
+            // it's not, so try the default
+            if(isset($codes[$setting['default']]))
+                $setting['value'] = $setting['default'];
+            
+            // default gone too, so use the first enabled currency
+            else {
+                foreach($currencies as $currency) {
+                    if(!$currency['enabled'])
+                        continue;
+                    $setting['value'] = $setting['default'] = $currency['cur_code'];
+                    break;
+                }
+            }
+        }
+        
+        $this->db->where('slug', 'firesale_currency')->update('settings', $setting);
+    }
 
 }

--- a/firesale/models/currency_m.php
+++ b/firesale/models/currency_m.php
@@ -26,17 +26,22 @@ class Currency_m extends MY_Model
         $this->load->driver('Streams');
     }
 
-    public function get($id = 1)
+    public function get($id = NULL)
     {
 
         // Check cache
-        if ( array_key_exists($id, $this->cache) ) {
+        if ( $id !== NULL && array_key_exists($id, $this->cache) ) {
             return $this->cache[$id];
         }
 
-        // Variables
-        $stream = $this->streams->streams->get_stream('firesale_currency', 'firesale_currency');
-        $row    = $this->row_m->get_row($id, $stream, false);
+        // if no id given, get the default currency
+        if($id === NULL) {
+            $default_currency = $this->db->select('value')->get_where('settings', array('slug' => 'firesale_currency'))->row();
+            $row = $this->db->get_where('firesale_currency', array('cur_code' => $default_currency->value))->row();
+        } else {
+            $stream = $this->streams->streams->get_stream('firesale_currency', 'firesale_currency');
+            $row    = $this->row_m->get_row($id, $stream, false);
+        }
 
         // Check it's valid
         if ($row) {
@@ -56,7 +61,7 @@ class Currency_m extends MY_Model
         return FALSE;
     }
 
-    public function get_symbol($id = 1)
+    public function get_symbol($id = NULL)
     {
 
         // Variables
@@ -84,7 +89,7 @@ class Currency_m extends MY_Model
         }
 
         // Get currency data
-        $currency = $this->get(( $currency != NULL ? $currency : 1 ));
+        $currency = $this->get($currency);
 
         // Check valid option
         if ( ! is_object($currency) ) {
@@ -194,7 +199,8 @@ class Currency_m extends MY_Model
     /**
      * Updates the options for the select/dropdown "Default Currency Code" in settings
      */
-    public function update_default_currency_options() {
+    public function update_default_currency_options()
+    {
         // get current setting
         $setting = $this->db->get_where('settings', array('slug' => 'firesale_currency'))->row_array();
 /*         var_dump($setting); */

--- a/firesale/models/orders_m.php
+++ b/firesale/models/orders_m.php
@@ -303,7 +303,7 @@ class Orders_m extends MY_Model
 
             // No currency set?
             if ($order['currency'] == NULL) {
-                $order['currency'] = $this->pyrocache->model('currency_m', 'get', array(1), $this->firesale->cache_time);
+                $order['currency'] = $this->pyrocache->model('currency_m', 'get', array(), $this->firesale->cache_time);
             }
 
             // Format prices
@@ -340,7 +340,7 @@ class Orders_m extends MY_Model
         }
 
         // Get currency
-        $user_currency = ( $this->session->userdata('currency') ? $this->session->userdata('currency') : 1 );
+        $user_currency = ( $this->session->userdata('currency') ? $this->session->userdata('currency') : NULL );
         $currency      = $this->currency_m->get($user_currency);
 
         // Append input
@@ -435,7 +435,7 @@ class Orders_m extends MY_Model
     {
 
         // Get tax rate
-        $user_currency = $this->session->userdata('currency') ? $this->session->userdata('currency') : 1;
+        $user_currency = $this->session->userdata('currency') ? $this->session->userdata('currency') : NULL;
         $currency      = $this->currency_m->get($user_currency);
 
         // Variables

--- a/firesale/models/products_m.php
+++ b/firesale/models/products_m.php
@@ -153,7 +153,7 @@ class Products_m extends MY_Model
 
         // Variables
         $user_currency = $this->session->userdata('currency');
-        $currency      = $currency ? $currency : ($user_currency ? $user_currency : 1);        
+        $currency      = $currency ? $currency : ($user_currency ? $user_currency : NULL);
 
         // Set params
         $params = array(

--- a/firesale/plugin.php
+++ b/firesale/plugin.php
@@ -275,7 +275,7 @@ class Plugin_Firesale extends Plugin
         $this->load->library('fs_cart');
 
         // Get currency
-        $currency = $this->currency_m->get(( $this->session->userdata('currency') ? $this->session->userdata('currency') : 1 ));
+        $currency = $this->currency_m->get(( $this->session->userdata('currency') ? $this->session->userdata('currency') : NULL ));
 
         // Variables
         $data 		 	= new stdClass;

--- a/firesale/widgets/firesale_cart/firesale_cart.php
+++ b/firesale/widgets/firesale_cart/firesale_cart.php
@@ -28,7 +28,7 @@ class Widget_FireSale_Cart extends Widgets
         $this->load->model('firesale/products_m');
 
         // Variables
-        $currency       = ( $this->session->userdata('currency') ? $this->session->userdata('currency') : 1 );
+        $currency       = ( $this->session->userdata('currency') ? $this->session->userdata('currency') : NULL );
         $contents       = $this->fs_cart->contents();
         $data           = new stdClass;
         $data->products = array();


### PR DESCRIPTION
In settings:
Instead of typing in a currency code, the admin can now select a currency from the list. I left the underlying value unchanged as the cur_code (though I think perhaps the id would make more sense), so this shouldn't have any ramifications elsewhere. I also set that list to be updated whenever a change is made in currencies.

Everywhere else:
Previously, everything defaulted to a hard-coded currency id 1, regardless of the Default Currency Code in the admin. Wherever I could find it, I removed the 1 or changed it to NULL. I then let the currency_m model grab the default currency if none is specified. I removed all the 1s that I found, but it's possible I missed a few.
