### PR TITLE
Categories plugin ordering

### DIFF
--- a/firesale/plugin.php
+++ b/firesale/plugin.php
@@ -117,6 +117,22 @@ class Plugin_Firesale extends Plugin
 
                     case 'parse_params':
                     break;
+                    
+                    // Decide the order if required, default to database order
+                    case 'order-by':
+                        if(isset($attributes['order-dir']))
+                        {
+                            $dir = $attributes['order-dir'];
+                        }
+                        else
+                        {
+                            $dir = 'asc';
+                        }
+                        $this->db->order_by($val, $dir);
+                        break;
+                    
+                    case 'order-dir':
+                        break;
 
                     default:
                         $query->where($key, $val);

--- a/firesale/plugin.php
+++ b/firesale/plugin.php
@@ -83,6 +83,15 @@ class Plugin_Firesale extends Plugin
 
         // Variables
         $attributes = $this->attributes();
+        
+        // if no ordering specified default to tree order
+        if(!isset($attributes['order']) and !isset($attributes['order-by']))
+        {
+            $attributes['order-by'] = 'ordering_count';
+            $attributes['order-dir'] = 'asc';
+        }
+        
+        // Are we cached?
         $cache_key  = md5(BASE_URL.implode('|', $attributes));
 
         // Get from cache
@@ -105,6 +114,7 @@ class Plugin_Firesale extends Plugin
                     case 'order':
                         list($by, $dir) = explode(' ', $val);
                         $query->order_by($by, $dir);
+                        $custom_order = true;
                     break;
 
                     case 'empty':
@@ -118,7 +128,7 @@ class Plugin_Firesale extends Plugin
                     case 'parse_params':
                     break;
                     
-                    // Decide the order if required, default to database order
+                    // Decide the order if required, default to tree ordering
                     case 'order-by':
                         if(isset($attributes['order-dir']))
                         {
@@ -128,7 +138,8 @@ class Plugin_Firesale extends Plugin
                         {
                             $dir = 'asc';
                         }
-                        $this->db->order_by($val, $dir);
+                        $query->order_by($val, $dir);
+                        $custom_order = true;
                         break;
                     
                     case 'order-dir':

--- a/firesale/plugin.php
+++ b/firesale/plugin.php
@@ -114,7 +114,6 @@ class Plugin_Firesale extends Plugin
                     case 'order':
                         list($by, $dir) = explode(' ', $val);
                         $query->order_by($by, $dir);
-                        $custom_order = true;
                     break;
 
                     case 'empty':
@@ -139,7 +138,6 @@ class Plugin_Firesale extends Plugin
                             $dir = 'asc';
                         }
                         $query->order_by($val, $dir);
-                        $custom_order = true;
                         break;
                     
                     case 'order-dir':

--- a/firesale/plugin.php
+++ b/firesale/plugin.php
@@ -85,10 +85,10 @@ class Plugin_Firesale extends Plugin
         $attributes = $this->attributes();
         
         // if no ordering specified default to tree order
-        if(!isset($attributes['order']) and !isset($attributes['order-by']))
-        {
-            $attributes['order-by'] = 'ordering_count';
-            $attributes['order-dir'] = 'asc';
+        if ( ! isset($attributes['order']) and ! isset($attributes['order-by']) ) {
+            $attributes['order'] = 'ordering_count asc';
+        } else if ( isset($attributes['order-by']) ) {
+            $attributes['order'] = $attributes['order-by'].' '.( isset($attributes['order-dir']) ? $attributes['order-dir'] : 'asc' );
         }
         
         // Are we cached?
@@ -126,22 +126,6 @@ class Plugin_Firesale extends Plugin
 
                     case 'parse_params':
                     break;
-                    
-                    // Decide the order if required, default to tree ordering
-                    case 'order-by':
-                        if(isset($attributes['order-dir']))
-                        {
-                            $dir = $attributes['order-dir'];
-                        }
-                        else
-                        {
-                            $dir = 'asc';
-                        }
-                        $query->order_by($val, $dir);
-                        break;
-                    
-                    case 'order-dir':
-                        break;
 
                     default:
                         $query->where($key, $val);

--- a/firesale/plugin.php
+++ b/firesale/plugin.php
@@ -125,6 +125,8 @@ class Plugin_Firesale extends Plugin
                     break;
 
                     case 'parse_params':
+                    case 'order-by':
+                    case 'order-dir':
                     break;
 
                     default:

--- a/firesale/views/category.php
+++ b/firesale/views/category.php
@@ -2,12 +2,12 @@
       <div class="firesale width-onefourth sidebar left">
         <h2>Categories</h2>
         <ul class="icon-arrow categories">
-{{ firesale:categories parent="0" }}
+{{ firesale:categories parent="0" order-by="title" order-dir="asc" }}
 {{ if parent == id }}
           <li>
             <a href="{{ firesale:url route="category" id=id }}"><strong>{{ title }}</strong></a>
             <ul>
-{{ firesale:sub_categories parent=id }}
+{{ firesale:sub_categories parent=id order-by="title" order-dir="desc" }}
               <li><a href="{{ firesale:url route="category" id=id }}">{{ if category.id == id }}<strong>{{ title }}</strong>{{ else }}{{ title }}{{ endif }}</a></li>{{ /firesale:sub_categories }}
             </ul>
           </li>

--- a/firesale/views/category.php
+++ b/firesale/views/category.php
@@ -2,12 +2,12 @@
       <div class="firesale width-onefourth sidebar left">
         <h2>Categories</h2>
         <ul class="icon-arrow categories">
-{{ firesale:categories parent="0" order-by="title" order-dir="asc" }}
+{{ firesale:categories parent="0" }}
 {{ if parent == id }}
           <li>
             <a href="{{ firesale:url route="category" id=id }}"><strong>{{ title }}</strong></a>
             <ul>
-{{ firesale:sub_categories parent=id order-by="title" order-dir="desc" }}
+{{ firesale:sub_categories parent=id }}
               <li><a href="{{ firesale:url route="category" id=id }}">{{ if category.id == id }}<strong>{{ title }}</strong>{{ else }}{{ title }}{{ endif }}</a></li>{{ /firesale:sub_categories }}
             </ul>
           </li>


### PR DESCRIPTION
I have updated the categories plugin ordering to match the documentation at 
https://www.getfiresale.org/documentation/themeing/plugins/categories

I have also set it to default to the tree ordering when no ordering is specified as users are confused when the ordering doesn't match the admin area ordering.
