### PR TITLE
Fix query to get products in widget

### DIFF
--- a/firesale/models/products_m.php
+++ b/firesale/models/products_m.php
@@ -247,7 +247,7 @@ class Products_m extends MY_Model
             } elseif ($key == 'search' AND strlen($value) > 0 ) {
                 $query->where("( p.`title` LIKE '%{$value}%' OR p.`code` LIKE '%{$value}%' OR p.`description` LIKE '%{$value}%' )");
             } elseif ($key == 'sale' AND $value == '1') {
-                $query->where('p.price <', 'p.rrp');
+                $query->where('p.price < p.rrp');
             } elseif ($key == 'price') {
                 list($from, $to) = explode('-', $value);
                 $query->where('p.price >=', $from)


### PR DESCRIPTION
I try to show product using firesale widget. No result found but when i check database, it exists and the parameters is correct.
When i check the query its contains .... WHERE  `p`.`price` < 'p.rrp' AND  ... i realized that the rrp considered as string .... so when i change the code to 
$query->where('p.price < p.rrp');

the query correct and now the products appear.
