### PR TITLE
Ability to choose whether to display a product modifier price difference or actual price

### DIFF
--- a/firesale/plugin.php
+++ b/firesale/plugin.php
@@ -305,9 +305,10 @@ class Plugin_Firesale extends Plugin
     {
 
         // Variables
-        $type    = $this->attribute('type', 'select'); // radio
-        $product = $this->attribute('product');
-        $product = $this->products_m->get_product($product);
+        $type       = $this->attribute('type', 'select'); // radio
+        $difference = $this->attribute('difference', 'difference'); // display the price difference or the actual price
+        $product    = $this->attribute('product');
+        $product    = $this->products_m->get_product($product);
 
         // Format data
         foreach ($product['modifiers'] as &$modifier) {
@@ -320,10 +321,11 @@ class Plugin_Firesale extends Plugin
         }
 
         // Assign data
-        $data            = new stdClass;
-        $data->type      = $type;
-        $data->product   = $product;
-        $data->modifiers = $product['modifiers'];
+        $data             = new stdClass;
+        $data->type       = $type;
+        $data->difference = $difference;
+        $data->product    = $product;
+        $data->modifiers  = $product['modifiers'];
 
         // Build form
         return $this->parser->parse('partials/modifier_form', $data, true);

--- a/firesale/views/partials/modifier_form.php
+++ b/firesale/views/partials/modifier_form.php
@@ -17,9 +17,9 @@
                     <?php foreach( $modifier['variations'] as $variation ): ?>
                     <?php if( $type == 'radio' ): ?>
                         <input type="radio" name="options[0][<?php echo $modifier['id']; ?>]" id="options_<?php echo $variation['id']; ?>" value="<?php echo $variation['id']; ?>" <?php echo $variation['selected']; ?>/>
-                        <label for="options_<?php echo $variation['id']; ?>"><?php echo $variation['title']; ?> (<?php echo $variation['difference']; ?>)</label>
+                        <label for="options_<?php echo $variation['id']; ?>"><?php echo $variation['title']; ?> (<?php if($difference == 'difference') { echo $variation['difference']; } else { echo $variation['product']['price_formatted']; } ?>)</label>
                     <?php else: ?>
-                            <option <?php echo $variation['selected']; ?>value="<?php echo $variation['id']; ?>"><?php echo $variation['title']; ?> (<?php echo $variation['difference']; ?>)</option>
+                            <option <?php echo $variation['selected']; ?>value="<?php echo $variation['id']; ?>"><?php echo $variation['title']; ?> (<?php if($difference == 'difference') { echo $variation['difference']; } else { echo $variation['product']['price_formatted']; } ?>)</option>
                     <?php endif; ?>
                     <?php endforeach; ?>
                     <?php if( $type == 'select' ): ?>


### PR DESCRIPTION
We have a use case where where we would like to display the actual price in the modifier form so I have added the ability to choose this in the modifier_form plugin. Simply set the difference attribute to 'difference' or 'price'. It defaults to 'difference' for backwards compatibility.
