### PR TITLE
Added index.php with BASE_URL contstant

### DIFF
--- a/firesale/plugin.php
+++ b/firesale/plugin.php
@@ -55,7 +55,7 @@ class Plugin_Firesale extends Plugin
         $url = $this->pyrocache->model('routes_m', 'build_url', array($route, $id), $this->firesale->cache_time);
 
         // Build the URL
-        return (($base == 'yes') ? BASE_URL : '').$url.$after;
+        return (($base == 'yes') ? BASE_URL.'index.php/' : '').$url.$after;
     }
 
     public function module_installed()


### PR DESCRIPTION
without index.php, routes doesn't work within a sub-folder installation such as <site>/pyro. 

In order to compatible with sub folder installation. index.php must be there within a BASE_URL constant
