### PR TITLE
Set correct location of redirect JS file

### DIFF
--- a/firesale/libraries/merchant.php
+++ b/firesale/libraries/merchant.php
@@ -323,7 +323,7 @@ class merchant
     {
         $_CI =& get_instance();
 
-        $template = $_CI->template->append_js('module::payment_redirection.js')
+        $template = $_CI->template->append_js('module::admin/payment_redirection.js')
                                   ->set('data', $data)
                                   ->set('post_url', $url)
                                   ->set('message', $message)


### PR DESCRIPTION
When 3d secure is required firesale looks in the wrong place for a javascript file resulting in a 500 error.

I have corrected the location.

You guys might want to check this as I believe that all card payments using 3dsecure are probably failing.
