### PR TITLE
Adding /cardsave to the TermURL param fixes Cardsave 3dSecure payments.

### DIFF
--- a/firesale/controllers/front/cart.php
+++ b/firesale/controllers/front/cart.php
@@ -731,7 +731,7 @@ class cart extends Public_Controller
                     'visa'       => 'Visa',
                     'maestro'    => 'Maestro',
                     'mastercard' => 'MasterCard',
-                    'discover'   => 'Discover'
+                    //'discover'   => 'Discover'
                 );
 
                 // Format currency

--- a/firesale/helpers/general_helper.php
+++ b/firesale/helpers/general_helper.php
@@ -77,7 +77,7 @@ function url($route, $id = null, $after = null)
 function format_currency($price, $currency = false, $fix = true, $apply_tax = false, $format = true)
 {
     ci()->load->model('firesale/currency_m'); 
-    if ( is_object(ci()->fs_cart) ) { $currency = $currency or ci()->fs_cart->currency(); }
+	if ( is_object(ci()->fs_cart) ) { if(!$currency) { $currency = ci()->fs_cart->currency(); } }
     else { ci()->load->model('settings_m'); $currency = cache('currency_m/get', Settings::get('firesale_currency')); }
     $formatted = cache('currency_m/format_string', $price, $currency, $fix, $apply_tax, $format);
     return $formatted;

--- a/firesale/libraries/gateways/merchant_cardsave.php
+++ b/firesale/libraries/gateways/merchant_cardsave.php
@@ -62,6 +62,8 @@ class Merchant_cardsave extends Merchant_driver
     private function _build_authorize_or_purchase($method)
     {
         $this->require_params('card_no', 'name', 'exp_month', 'exp_year', 'csc');
+		
+		var_dump($this->param('amount'));
 
         $request = $this->_new_request('CardDetailsTransaction');
         $request->PaymentMessage->MerchantAuthentication['MerchantID'] = $this->setting('merchant_id');
@@ -123,6 +125,8 @@ class Merchant_cardsave extends Merchant_driver
 
     private function _post_cardsave_request($request)
     {
+		var_dump($request);
+		die;
         // the PHP SOAP library sucks, and SimpleXML can't append element trees
         $document = new DOMDocument('1.0', 'utf-8');
         $envelope = $document->appendChild($document->createElementNS('http://schemas.xmlsoap.org/soap/envelope/', 'soap:Envelope'));

--- a/firesale/libraries/gateways/merchant_cardsave.php
+++ b/firesale/libraries/gateways/merchant_cardsave.php
@@ -151,7 +151,7 @@ class Merchant_cardsave extends Merchant_driver
                 // redirect for 3d authentication
                 $data = array(
                     'PaReq' => (string) $response->TransactionOutputData->ThreeDSecureOutputData->PaREQ,
-                    'TermUrl' => $this->param('return_url'),
+                    'TermUrl' => $this->param('return_url') . '/cardsave',
                     'MD' => (string) $response->TransactionOutputData['CrossReference'],
                 );
 

--- a/firesale/libraries/gateways/merchant_cardsave.php
+++ b/firesale/libraries/gateways/merchant_cardsave.php
@@ -62,8 +62,6 @@ class Merchant_cardsave extends Merchant_driver
     private function _build_authorize_or_purchase($method)
     {
         $this->require_params('card_no', 'name', 'exp_month', 'exp_year', 'csc');
-		
-		var_dump($this->param('amount'));
 
         $request = $this->_new_request('CardDetailsTransaction');
         $request->PaymentMessage->MerchantAuthentication['MerchantID'] = $this->setting('merchant_id');
@@ -125,8 +123,6 @@ class Merchant_cardsave extends Merchant_driver
 
     private function _post_cardsave_request($request)
     {
-		var_dump($request);
-		die;
         // the PHP SOAP library sucks, and SimpleXML can't append element trees
         $document = new DOMDocument('1.0', 'utf-8');
         $envelope = $document->appendChild($document->createElementNS('http://schemas.xmlsoap.org/soap/envelope/', 'soap:Envelope'));


### PR DESCRIPTION
Not sure if this is the best way of doing it as I am not sure where that parameter is set originally, but this fixes the problem for me.

References #414 
