### PR TITLE
Fixes for Cardsave TermURL, and Shipping Cost Tax

### DIFF
--- a/firesale/controllers/front/cart.php
+++ b/firesale/controllers/front/cart.php
@@ -731,7 +731,7 @@ class cart extends Public_Controller
                     'visa'       => 'Visa',
                     'maestro'    => 'Maestro',
                     'mastercard' => 'MasterCard',
-                    'discover'   => 'Discover'
+                    //'discover'   => 'Discover'
                 );
 
                 // Format currency

--- a/firesale/helpers/general_helper.php
+++ b/firesale/helpers/general_helper.php
@@ -77,7 +77,7 @@ function url($route, $id = null, $after = null)
 function format_currency($price, $currency = false, $fix = true, $apply_tax = false, $format = true)
 {
     ci()->load->model('firesale/currency_m'); 
-    if ( is_object(ci()->fs_cart) ) { $currency = $currency or ci()->fs_cart->currency(); }
+	if ( is_object(ci()->fs_cart) ) { if(!$currency) { $currency = ci()->fs_cart->currency(); } }
     else { ci()->load->model('settings_m'); $currency = cache('currency_m/get', Settings::get('firesale_currency')); }
     $formatted = cache('currency_m/format_string', $price, $currency, $fix, $apply_tax, $format);
     return $formatted;

--- a/firesale/libraries/gateways/merchant_cardsave.php
+++ b/firesale/libraries/gateways/merchant_cardsave.php
@@ -62,6 +62,8 @@ class Merchant_cardsave extends Merchant_driver
     private function _build_authorize_or_purchase($method)
     {
         $this->require_params('card_no', 'name', 'exp_month', 'exp_year', 'csc');
+		
+		var_dump($this->param('amount'));
 
         $request = $this->_new_request('CardDetailsTransaction');
         $request->PaymentMessage->MerchantAuthentication['MerchantID'] = $this->setting('merchant_id');
@@ -123,6 +125,8 @@ class Merchant_cardsave extends Merchant_driver
 
     private function _post_cardsave_request($request)
     {
+		var_dump($request);
+		die;
         // the PHP SOAP library sucks, and SimpleXML can't append element trees
         $document = new DOMDocument('1.0', 'utf-8');
         $envelope = $document->appendChild($document->createElementNS('http://schemas.xmlsoap.org/soap/envelope/', 'soap:Envelope'));

--- a/firesale/libraries/gateways/merchant_cardsave.php
+++ b/firesale/libraries/gateways/merchant_cardsave.php
@@ -151,7 +151,7 @@ class Merchant_cardsave extends Merchant_driver
                 // redirect for 3d authentication
                 $data = array(
                     'PaReq' => (string) $response->TransactionOutputData->ThreeDSecureOutputData->PaREQ,
-                    'TermUrl' => $this->param('return_url'),
+                    'TermUrl' => $this->param('return_url') . '/cardsave',
                     'MD' => (string) $response->TransactionOutputData['CrossReference'],
                 );
 

--- a/firesale/libraries/gateways/merchant_cardsave.php
+++ b/firesale/libraries/gateways/merchant_cardsave.php
@@ -62,8 +62,6 @@ class Merchant_cardsave extends Merchant_driver
     private function _build_authorize_or_purchase($method)
     {
         $this->require_params('card_no', 'name', 'exp_month', 'exp_year', 'csc');
-		
-		var_dump($this->param('amount'));
 
         $request = $this->_new_request('CardDetailsTransaction');
         $request->PaymentMessage->MerchantAuthentication['MerchantID'] = $this->setting('merchant_id');
@@ -125,8 +123,6 @@ class Merchant_cardsave extends Merchant_driver
 
     private function _post_cardsave_request($request)
     {
-		var_dump($request);
-		die;
         // the PHP SOAP library sucks, and SimpleXML can't append element trees
         $document = new DOMDocument('1.0', 'utf-8');
         $envelope = $document->appendChild($document->createElementNS('http://schemas.xmlsoap.org/soap/envelope/', 'soap:Envelope'));

--- a/firesale/models/cart_m.php
+++ b/firesale/models/cart_m.php
@@ -237,7 +237,7 @@ class Cart_m extends MY_Model
             'cancel_url' => site_url($this->pyrocache->model('routes_m', 'build_url', array('cart'), $this->firesale->cache_time) . '/cancel')
         ), $override ? $override : array(), array(
             'currency_code'  => $this->fs_cart->currency()->cur_code,
-            'amount'         => $this->fs_cart->total() + $order['shipping']['price'],
+            'amount'         => $this->fs_cart->total() + ($order['shipping']['price'] / 1.2),
             'order_id'       => $this->session->userdata('order_id'),
             'transaction_id' => $this->session->userdata('order_id'),
             'reference'      => 'Order #' . $this->session->userdata('order_id'),


### PR DESCRIPTION
Commit #1c705e2 ensures that a currency is actually loaded. If is isn't then decimal places are not inserted into costs which can result in the user being charged thousands when they expected to pay tens.

Commit #7752233 removes the tax amount from the cost about to be charged to a card inline with the rest of the checkout and order confirmations. This will probably need to be changed back once the shipping tax is considered throughout the checkout process.

Also refs #414 in Commit #e27f9f1
