### PR TITLE
Allowing products of a fixed price to be found by the AJAX controller

### DIFF
--- a/firesale/models/products_m.php
+++ b/firesale/models/products_m.php
@@ -261,8 +261,8 @@ class Products_m extends MY_Model
                 $query->order_by('p.'.$key, $value);
             } elseif ($key == 'price') {
                 list($from, $to) = explode('-', $value);
-                $query->where('p.price >=', $from)
-                      ->where('p.price <=', $to);
+                $query->where('cast(p.price as decimal(6, 2)) >=', $from)
+                      ->where('cast(p.price as decimal(6, 2)) <=', $to);
             } elseif ($key == 'new' ) {
                 $new = (int)$this->settings->get('firesale_new');
                 $query->where('p.created >=', date('Y-m-d H:i:s', ( time() - $new )));


### PR DESCRIPTION
Casting prices to decimal means it'll match, otherwise the rounding errors caused by storing the prices as a float means that a static price is never matched from the javascript slider.

This problem might be unique to our storefront.  All our items are priced the same and because of how the monetary values are stored in the database as floats when the ajax controller gets to the 'price' part of the filter the slider is setting an absolute to / from value based on the maximum and minimum prices in the db (£19.99 / £19.99) which, when compared against the float values pulled from the database clearly don't match.  The following will return 0 values:

```
19.99 >= 19.9899997711181600 
AND
19.99 <= 19.9899997711181600

#Float value taken directly from the DB:
SELECT CAST(price AS DECIMAL(30, 16)) from default_firesale_products where id = 1;
```
